### PR TITLE
Fixed Decimal Places Not being checked when squaring numbers

### DIFF
--- a/CalculatorApp/Helpers/CalculatorHelper.cs
+++ b/CalculatorApp/Helpers/CalculatorHelper.cs
@@ -35,8 +35,8 @@ namespace CalculatorApp.Helpers
                 if (formattedString.Contains("²"))
                 {
                     // Extract the base number
-                        string baseNumberStr = Regex.Match(formattedString, @"\d+(\.\d+)?").Value;
-                        double baseNumber = double.Parse(baseNumberStr);
+                    string baseNumberStr = Regex.Match(formattedString, @"\d+(\.\d+)?").Value;
+                    double baseNumber = double.Parse(baseNumberStr);
 
                     double result = Math.Pow(baseNumber, 2);
 

--- a/CalculatorApp/Helpers/CalculatorHelper.cs
+++ b/CalculatorApp/Helpers/CalculatorHelper.cs
@@ -35,8 +35,8 @@ namespace CalculatorApp.Helpers
                 if (formattedString.Contains("²"))
                 {
                     // Extract the base number
-                    string baseNumberStr = Regex.Match(formattedString, @"\d+").Value;
-                    double baseNumber = double.Parse(baseNumberStr);
+                        string baseNumberStr = Regex.Match(formattedString, @"\d+(\.\d+)?").Value;
+                        double baseNumber = double.Parse(baseNumberStr);
 
                     double result = Math.Pow(baseNumber, 2);
 


### PR DESCRIPTION
Fixed a bug where squaring a number with decimal places wouldnt work due to a bad regex